### PR TITLE
Update Microphone.cs to use lengthSec to change clip duration.

### DIFF
--- a/Runtime/WebGL/Microphone.cs
+++ b/Runtime/WebGL/Microphone.cs
@@ -106,7 +106,7 @@ namespace UnityEngine
                 : SAMPLES_PER_UPDATE_LOWFREQ;
             var clip = AudioClip.Create(
                 name: "Microphone AudioClip",
-                lengthSamples: samplesPerUpdate*LENGTH_SAMPLES_MULTIPLIER,
+                lengthSamples: samplesPerUpdate*LENGTH_SAMPLES_MULTIPLIER*lengthSec,
                 channels: 1,
                 frequency: sampleRate,
                 stream: false


### PR DESCRIPTION
Resolves #2 

Modified Microphone.cs Start() method to use the lengthSec parameter to change the length of the clip created. I've used this in a new project for recording the microphone input in WebGL to send the clip to a speech-to-text API.